### PR TITLE
fix: correcao no rabbimq/amqp para manter o conexao aberta

### DIFF
--- a/app-orders/src/broker/broker.ts
+++ b/app-orders/src/broker/broker.ts
@@ -1,7 +1,13 @@
 import amqp from 'amqplib';
 
-if(!process.env.BROKER_URL) {
+if (!process.env.BROKER_URL) {
   throw new Error('BROKER_URL must be configured.');
 }
 
 export const broker = await amqp.connect(process.env.BROKER_URL);
+
+export const ordersChannel = await broker.createChannel();
+
+await ordersChannel.assertQueue('orders'); /* Nome da Fila */
+
+console.log('[BROKER] Orders channel is ready');

--- a/app-orders/src/broker/channels/orders.ts
+++ b/app-orders/src/broker/channels/orders.ts
@@ -1,5 +1,3 @@
-import { broker } from '../broker.ts'
+import { ordersChannel  } from '../broker.ts';
 
-export const orders = await broker.createChannel()
-
-await orders.assertQueue('orders') /* Nome da Fila */
+export const orders = ordersChannel;

--- a/app-orders/src/http/server.ts
+++ b/app-orders/src/http/server.ts
@@ -11,7 +11,7 @@ import {
   validatorCompiler,
   type ZodTypeProvider
 } from 'fastify-type-provider-zod'
-//import { channels } from '../broker/channels/index.ts'
+import { channels } from '../broker/channels/index.ts'
 import { schema } from '../db/schema/index.ts'
 import { db } from '../db/client.ts'
 import { dispatchOrderCreated } from '../broker/messages/order-created.ts'

--- a/docker/kong/config.yaml
+++ b/docker/kong/config.yaml
@@ -16,6 +16,7 @@ services:
           - https
         paths:
           - /orders
+        strip_path: true
 
   - name: invoices
     url: http://host.docker.internal:3334


### PR DESCRIPTION
Foi identificado que, na tentativa de gerar uma operação do tipo GET, era retornado a seguinte mensagem:

{
  "statusCode": 500,
  "error": "Internal Server Error",
  "message": "Channel closed"
}

O canal estava sendo criado mas era imediatamente fechado. A correção aplicada foi para que o canal se mantém ele aberto durante toda a execução do app.